### PR TITLE
Properly get rid of copyText

### DIFF
--- a/plugins/ViewRaw/src/RawPage.tsx
+++ b/plugins/ViewRaw/src/RawPage.tsx
@@ -1,6 +1,5 @@
 import { findByProps as getByProps } from "@vendetta/metro"
 import { ReactNative, constants as Constants, clipboard } from "@vendetta/metro/common"
-import { copyText } from "@vendetta/utils"
 import { showToast } from "@vendetta/ui/toasts"
 import { getAssetIDByName as getAssetId } from "@vendetta/ui/assets"
 


### PR DESCRIPTION
this probably isn't necessary but i want to make sure your plugins don't explode